### PR TITLE
Don't force compiler flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,11 +221,6 @@ IF(WINDOWS)
 	SET(CMAKE_EXE_LINKER_FLAGS "-static -static-libgcc -static-libstdc++")
 ENDIF(WINDOWS)
 
-# by default, cmake should create only 'release' build with optimization and without debug routines
-ADD_DEFINITIONS(-DNDEBUG)
-ADD_DEFINITIONS(-O2)
-
-
 IF(WINDOWS)
 	# WIN32 - suppress terminal
 	ADD_EXECUTABLE(astromenace WIN32 ${astromenace_SRCS})


### PR DESCRIPTION
Applications generally may not override optimization and debug flags, which may be provided by the environment.
Forcing -O2 and -DNODEBUG also disallows debug builds unconditionally. CMake has build types (`cmake -DCMAKE_BUILD_TYPE=Release/Debug`) to handle this.