### PR TITLE
Fix string escaping in ADD_DEFINITIONS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,7 +211,7 @@ MESSAGE("Game data dir: ${astromenace_DATA}")
 
 # custom game data sources location
 IF(DATADIR)
-	ADD_DEFINITIONS(-DDATADIR=\\"${DATADIR}\\")
+	ADD_DEFINITIONS(-DDATADIR="${DATADIR}")
 ENDIF(DATADIR)
 
 IF(WINDOWS)


### PR DESCRIPTION
Recent CMake handles this on its own and does not need a lot of backslashes.