### PR TITLE
Always store vfs in the project binary dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,6 +245,6 @@ IF(NOT DONTCREATEVFS)
 	ADD_CUSTOM_COMMAND(
 		TARGET astromenace
 		POST_BUILD
-		COMMAND ${CMAKE_BINARY_DIR}/${astromenace_BIN} --pack --rawdata=${astromenace_DATA}
+		COMMAND ${CMAKE_BINARY_DIR}/${astromenace_BIN} --pack --rawdata=${astromenace_DATA} --dir=${PROJECT_BINARY_DIR}
 	)
 ENDIF(NOT DONTCREATEVFS)


### PR DESCRIPTION
This is needed when DATADIR is set - regardless of the setting, vfs file must end up in the build directory.