### PR TITLE
Fix build with GCC 13

### DIFF
--- a/src/core/model3d/model3d.cpp
+++ b/src/core/model3d/model3d.cpp
@@ -29,6 +29,7 @@
 #include "../vfs/vfs.h"
 #include "model3d.h"
 #include <cmath>
+#include <cstdint>
 #include <cstring>
 #include <fstream>
 


### PR DESCRIPTION
GCC 13 (as usual for new compiler releases) shuffles around some internal includes and so etc is no longer transitively included:
```
/var/tmp/portage/games-action/astromenace-1.4.2/work/astromenace-1.4.2/src/core/model3d/model3d.cpp: In member function ‘bool viewizard::cModel3DWrapper::LoadVW3D(const std::string&)’:
/var/tmp/portage/games-action/astromenace-1.4.2/work/astromenace-1.4.2/src/core/model3d/model3d.cpp:602:10: error: ‘uint32_t’ is not a member of ‘std’; did you mean ‘wint_t’?
  602 |     std::uint32_t ChunkArraySize;
      |          ^~~~~~~~
      |          wint_t
/var/tmp/portage/games-action/astromenace-1.4.2/work/astromenace-1.4.2/src/core/model3d/model3d.cpp:603:18: error: ‘ChunkArraySize’ was not declared in this scope
  603 |     File->fread(&ChunkArraySize, sizeof(ChunkArraySize), 1);
      |                  ^~~~~~~~~~~~~~
/var/tmp/portage/games-action/astromenace-1.4.2/work/astromenace-1.4.2/src/core/model3d/model3d.cpp: In member function ‘bool viewizard::cModel3DWrapper::SaveVW3D(const std::string&)’:
/var/tmp/portage/games-action/astromenace-1.4.2/work/astromenace-1.4.2/src/core/model3d/model3d.cpp:681:10: error: ‘uint32_t’ is not a member of ‘std’; did you mean ‘wint_t’?
  681 |     std::uint32_t ChunkArraySize = static_cast<std::uint32_t>(Chunks.size());
      |          ^~~~~~~~
      |          wint_t
/var/tmp/portage/games-action/astromenace-1.4.2/work/astromenace-1.4.2/src/core/model3d/model3d.cpp:682:45: error: ‘ChunkArraySize’ was not declared in this scope
  682 |     FileVW3D.write(reinterpret_cast<char*>(&ChunkArraySize), sizeof(ChunkArraySize));
      |                                             ^~~~~~~~~~~~~~
```

See https://gnu.org/software/gcc/gcc-13/porting_to.html.

Bug: https://bugs.gentoo.org/895760