### PR TITLE
Include <stdint.h> in base.h

### DIFF
--- a/src/core/base.h
+++ b/src/core/base.h
@@ -48,6 +48,7 @@
 #include <locale>
 #include <iostream>
 #include <functional>
+#include <stdint.h>
 
 // don't setup NDEBUG in sources, use definition in build system instead
 #include <cassert>


### PR DESCRIPTION
This is needed for `uint32_t`, used in several headers.

Use `<stdint.h>` not `<cstdint>` because the code uses `uint32_t` not `std::uint32_t`.