### PR TITLE
UNIX: add _DEFAULT_SOURCE and _BSD_SOURCE for using vfork()

### DIFF
--- a/src/core/platform/open_url.cpp
+++ b/src/core/platform/open_url.cpp
@@ -25,6 +25,12 @@
 
 *****************************************************************************/
 
+// Required for supporting vfork() with glibc
+#ifdef __unix
+#define _DEFAULT_SOURCE // Since glibc 2.19
+#define _BSD_SOURCE // glibc <= 2.19
+#endif // __unix
+
 #include "../base.h"
 #ifdef __unix
 #include <unistd.h>


### PR DESCRIPTION
I'm getting this error when building the source code here:
```
src/core/platform/open_url.cpp: In function ‘bool viewizard::vw_OpenWebsiteURL(const std::string&)’: 
src/core/platform/open_url.cpp:55:22: error: ‘vfork’ was not declared in this scope; did you mean ‘fork’?
   55 |         pid_t pid2 = vfork();
      |                      ^~~~~
      |                      fork
```
According to this page:

https://man7.org/linux/man-pages/man2/vfork.2.html

it is required to have `_DEFAULT_SOURCE` or `_BSD_SOURCE` to be defined for using `vfork()`.
It is possible that they can be already defined, but it seems to be not my case.
So, I added these macros into `open_url.cpp` as the above documentation required and I have been able to complete the build.
Declaring those macros into the `#ifdef __unix ... #endif` block doesn't work, they need to be declared before everything on my side.
I hope that you will find it useful.
